### PR TITLE
Add type "module" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "simpler state management",
   "main": "main.js",
   "module": "main.js",
+  "type" : "module",
   "scripts": {
     "test": "mocha -r esm tests"
   },


### PR DESCRIPTION
## Description

In order to use properly this package in NodeJS environment, I add a property `"type": "module"` in the `package.json` so that NodeJS knows how to load this module. 

I needed this as I want to use an `import` of this package while using [Mocha](https://mochajs.org/).

## Ressources 

> Code that contains syntax that only parses successfully as [ES modules](https://nodejs.org/api/esm.html), such as import or export statements or import.meta, when the code has no explicit marker of how it should be interpreted. Explicit markers are .mjs or .cjs extensions, package.json "type" fields with either "module" or "commonjs" values, or --input-type or --experimental-default-type flags. Dynamic import() expressions are supported in either CommonJS or ES modules and would not cause a file to be treated as an ES module.

> Files ending in .js or with no extension, if the nearest parent package.json field lacks a "type" field; unless the folder is inside a node_modules folder. (Package scopes under node_modules are always treated as CommonJS when the package.json file lacks a "type" field, regardless of --experimental-default-type, for backward compatibility.)

https://nodejs.org/api/packages.html